### PR TITLE
Fix load order

### DIFF
--- a/lib/grpc_mock.rb
+++ b/lib/grpc_mock.rb
@@ -34,4 +34,8 @@ module GrpcMock
       @config ||= Configuration.new
     end
   end
+
+  # Hook into GRPC::ClientStub
+  # https://github.com/grpc/grpc/blob/bec3b5ada2c5e5d782dff0b7b5018df646b65cb0/src/ruby/lib/grpc/generic/service.rb#L150-L186
+  GRPC::ClientStub.prepend GrpcStubAdapter::MockStub
 end

--- a/lib/grpc_mock/grpc_stub_adapter.rb
+++ b/lib/grpc_mock/grpc_stub_adapter.rb
@@ -8,7 +8,7 @@ module GrpcMock
   class GrpcStubAdapter
     # To make hook point for GRPC::ClientStub
     # https://github.com/grpc/grpc/blob/bec3b5ada2c5e5d782dff0b7b5018df646b65cb0/src/ruby/lib/grpc/generic/service.rb#L150-L186
-    class AdapterClass < GRPC::ClientStub
+    module MockStub
       def request_response(method, request, *args, **opts)
         unless GrpcMock::GrpcStubAdapter.enabled?
           return super
@@ -78,8 +78,7 @@ module GrpcMock
         end
       end
     end
-    GRPC.send(:remove_const, :ClientStub)
-    GRPC.send(:const_set, :ClientStub, AdapterClass)
+    GRPC::ClientStub.prepend MockStub
 
     def self.disable!
       @enabled = false

--- a/lib/grpc_mock/grpc_stub_adapter.rb
+++ b/lib/grpc_mock/grpc_stub_adapter.rb
@@ -6,8 +6,6 @@ require 'grpc_mock/operation_stub'
 
 module GrpcMock
   class GrpcStubAdapter
-    # To make hook point for GRPC::ClientStub
-    # https://github.com/grpc/grpc/blob/bec3b5ada2c5e5d782dff0b7b5018df646b65cb0/src/ruby/lib/grpc/generic/service.rb#L150-L186
     module MockStub
       def request_response(method, request, *args, **opts)
         unless GrpcMock::GrpcStubAdapter.enabled?
@@ -78,7 +76,6 @@ module GrpcMock
         end
       end
     end
-    GRPC::ClientStub.prepend MockStub
 
     def self.disable!
       @enabled = false


### PR DESCRIPTION
Before this change, `grpc_mock/rspec` had to be loaded before the Rails application was. Now it's smarter and doesn't