### PR TITLE
add ability to stub requests with params

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,23 @@ client.hello(Hello::HelloRequest.new(msg: 'hi'))    # => Hello::HelloResponse.ne
 ### Stubbing per-action requests based on parametrized request
 
 ```ruby
-rpc_action  = OpenStruct.new(input: Hello::HelloRequest, output: Hello::HelloResponse)
+rpc_action = OpenStruct.new(input: Hello::HelloRequest, output: Hello::HelloResponse)
 GrpcMock.stub_grpc_action("/hello.hello/Hello", rpc_action).with(msg: 'hi').to_return(msg: 'test')
+
+client = Hello::Hello::Stub.new('localhost:8000', :this_channel_is_insecure)
+client.hello(Hello::HelloRequest.new(msg: 'hello')) # => send a request to server
+client.hello(Hello::HelloRequest.new(msg: 'hi'))    # => Hello::HelloResponse.new(msg: 'test') (without any requests to server)
+
+```
+
+### You can user either proto objects or hash for stubbing requests
+
+```ruby
+rpc_action = OpenStruct.new(input: Hello::HelloRequest, output: Hello::HelloResponse)
+
+GrpcMock.stub_grpc_action("/hello.hello/Hello", rpc_action).with(Hello::HelloRequest.new(msg: 'hi')).to_return(msg: 'test')
+# or
+GrpcMock.stub_grpc_action("/hello.hello/Hello", rpc_action).with(msg: 'hi').to_return(Hello::HelloResponse.new(msg: 'test'))
 
 client = Hello::Hello::Stub.new('localhost:8000', :this_channel_is_insecure)
 client.hello(Hello::HelloRequest.new(msg: 'hello')) # => send a request to server

--- a/README.md
+++ b/README.md
@@ -46,7 +46,18 @@ GrpcMock.stub_request("/hello.hello/Hello").with(Hello::HelloRequest.new(msg: 'h
 
 client = Hello::Hello::Stub.new('localhost:8000', :this_channel_is_insecure)
 client.hello(Hello::HelloRequest.new(msg: 'hello')) # => send a request to server
-client client.hello(Hello::HelloRequest.new(msg: 'hi'))    # => Hello::HelloResponse.new(msg: 'test') (without any requests to server)
+client.hello(Hello::HelloRequest.new(msg: 'hi'))    # => Hello::HelloResponse.new(msg: 'test') (without any requests to server)
+```
+
+### Stubbing per-action requests based on parametrized request
+
+```ruby
+rpc_action  = OpenStruct.new(input: Hello::HelloRequest, output: Hello::HelloResponse)
+GrpcMock.stub_grpc_action("/hello.hello/Hello", rpc_action).with(msg: 'hi').to_return(msg: 'test')
+
+client = Hello::Hello::Stub.new('localhost:8000', :this_channel_is_insecure)
+client.hello(Hello::HelloRequest.new(msg: 'hello')) # => send a request to server
+client.hello(Hello::HelloRequest.new(msg: 'hi'))    # => Hello::HelloResponse.new(msg: 'test') (without any requests to server)
 ```
 
 ### Real requests to network can be allowed or disabled
@@ -91,4 +102,3 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/ganmac
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-

--- a/lib/grpc_mock/action_stub.rb
+++ b/lib/grpc_mock/action_stub.rb
@@ -12,13 +12,13 @@ module GrpcMock
     # @param proto [Object] request proto object
     # @param request [Hash] parameters for request
     def with(proto = nil, **request)
-      proto ? super : super(@rpc_action.input.new(request))
+      proto ? super(proto) : super(@rpc_action.input.new(request))
     end
 
     # @param proto [Object] response proto object
     # @param response [Hash] parameters to respond with
     def to_return(proto = nil, **response)
-      proto ? super : super(@rpc_action.output.new(response))
+      proto ? super(proto) : super(@rpc_action.output.new(response))
     end
   end
 end

--- a/lib/grpc_mock/action_stub.rb
+++ b/lib/grpc_mock/action_stub.rb
@@ -9,15 +9,16 @@ module GrpcMock
       super(path)
     end
 
-    # @param request [Hash] a list of parameters for request
-    def with(**request)
-      super(@rpc_action.input.new(request))
+    # @param proto [Object] request proto object
+    # @param request [Hash] parameters for request
+    def with(proto = nil, **request)
+      proto ? super : super(@rpc_action.input.new(request))
     end
 
-    # @param responses [Array<Hash>] one or list of response objects
-    def to_return(*responses)
-      values = [*responses].flatten.map { |v| @rpc_action.output.new(v) }
-      super(values)
+    # @param proto [Object] response proto object
+    # @param response [Hash] parameters to respond with
+    def to_return(proto = nil, **response)
+      proto ? super : super(@rpc_action.output.new(response))
     end
   end
 end

--- a/lib/grpc_mock/action_stub.rb
+++ b/lib/grpc_mock/action_stub.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module GrpcMock
+  class ActionStub < RequestStub
+    # @param path [String] gRPC path like /${service_name}/${method_name}
+    # @param rpc_action [GRPC::RpcDesc] instance with parameters like +name+, +input+, +output+ and others
+    def initialize(path, rpc_action)
+      @rpc_action = rpc_action
+      super(path)
+    end
+
+    # @param request [Hash] a list of parameters for request
+    def with(**request)
+      super(@rpc_action.input.new(request))
+    end
+
+    # @param responses [Array<Hash>] one or list of response objects
+    def to_return(*responses)
+      values = [*responses].flatten.map { |v| @rpc_action.output.new(v) }
+      super(values)
+    end
+  end
+end

--- a/lib/grpc_mock/api.rb
+++ b/lib/grpc_mock/api.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'grpc_mock/request_stub'
+require 'grpc_mock/action_stub'
 require 'grpc_mock/matchers/request_including_matcher'
 
 module GrpcMock
@@ -8,6 +9,10 @@ module GrpcMock
     # @param path [String]
     def stub_request(path)
       GrpcMock.stub_registry.register_request_stub(GrpcMock::RequestStub.new(path))
+    end
+
+    def stub_grpc_action(path, rpc_action)
+      GrpcMock.stub_registry.register_request_stub(GrpcMock::ActionStub.new(path, rpc_action))
     end
 
     # @param values [Hash]

--- a/spec/grpc_mock/action_stub_spec.rb
+++ b/spec/grpc_mock/action_stub_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe GrpcMock::ActionStub do
+  let(:stub_grpc_action) do
+    described_class.new(path, action)
+  end
+
+  let(:path) do
+    '/service_name/method_name'
+  end
+
+  let(:action) do
+    double(input: input_class, output: output_class)
+  end
+
+  let(:input_class) { double }
+  let(:output_class) { double }
+
+  before do
+    allow(input_class).to receive(:new) { |arg| arg }
+    allow(output_class).to receive(:new) { |arg| arg }
+  end
+
+  describe '#response' do
+    let(:exception) { StandardError.new }
+    let(:value1) { :response_1 }
+    let(:value2) { :response_2 }
+    let(:value3) { :response_3 }
+
+    it 'returns response' do
+      stub_grpc_action.to_return(value1)
+      expect(stub_grpc_action.response.evaluate).to eq(value1)
+    end
+
+    it 'raises exception' do
+      stub_grpc_action.to_raise(exception)
+      expect { stub_grpc_action.response.evaluate }.to raise_error(StandardError)
+    end
+
+    it 'returns responses in a sequence passed as array' do
+      stub_grpc_action.to_return(value1, value2)
+      expect(stub_grpc_action.response.evaluate).to eq(value1)
+      expect(stub_grpc_action.response.evaluate).to eq(value2)
+    end
+
+    it 'returns responses in a sequence passed as array with multiple to_return calling' do
+      stub_grpc_action.to_return(value1, value2)
+      stub_grpc_action.to_return(value3)
+      expect(stub_grpc_action.response.evaluate).to eq(value1)
+      expect(stub_grpc_action.response.evaluate).to eq(value2)
+      expect(stub_grpc_action.response.evaluate).to eq(value3)
+    end
+
+    it 'repeats returning last response' do
+      stub_grpc_action.to_return(value1, value2)
+      expect(stub_grpc_action.response.evaluate).to eq(value1)
+      expect(stub_grpc_action.response.evaluate).to eq(value2)
+      expect(stub_grpc_action.response.evaluate).to eq(value2)
+      expect(stub_grpc_action.response.evaluate).to eq(value2)
+    end
+
+    context 'when not calling #to_return' do
+      it 'raises an error' do
+        expect { stub_grpc_action.response }.to raise_error(GrpcMock::NoResponseError)
+      end
+    end
+  end
+
+  describe '#to_return' do
+    let(:response) { double(:response) }
+
+    it 'registers response' do
+      expect(GrpcMock::ResponsesSequence).to receive(:new).with([GrpcMock::Response::Value]).once
+      expect(stub_grpc_action.to_return(response)).to eq(stub_grpc_action)
+    end
+
+    it 'registers multi responses' do
+      expect(GrpcMock::ResponsesSequence).to receive(:new).with([GrpcMock::Response::Value, GrpcMock::Response::Value]).once
+      expect(stub_grpc_action.to_return(response, response)).to eq(stub_grpc_action)
+    end
+  end
+
+  describe '#to_raise' do
+    context 'with string' do
+      let(:exception) { 'string' }
+      it 'registers exception' do
+        expect(GrpcMock::ResponsesSequence).to receive(:new).with([GrpcMock::Response::ExceptionValue]).once
+        expect(stub_grpc_action.to_raise(exception)).to eq(stub_grpc_action)
+      end
+    end
+
+    context 'with class' do
+      let(:response) { StandardError }
+      it 'registers exception' do
+        expect(GrpcMock::ResponsesSequence).to receive(:new).with([GrpcMock::Response::ExceptionValue]).once
+        expect(stub_grpc_action.to_raise(response)).to eq(stub_grpc_action)
+      end
+    end
+
+    context 'with exception instance' do
+      let(:response) { StandardError.new('message') }
+      it 'registers exception' do
+        expect(GrpcMock::ResponsesSequence).to receive(:new).with([GrpcMock::Response::ExceptionValue]).once
+        expect(stub_grpc_action.to_raise(response)).to eq(stub_grpc_action)
+      end
+    end
+
+    context 'with invalid value (integer)' do
+      let(:response) { 1 }
+      it 'raises ArgumentError' do
+        expect { stub_grpc_action.to_raise(response) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with multi exceptions' do
+      let(:exception) { StandardError.new('message') }
+      it 'registers exceptions' do
+        expect(GrpcMock::ResponsesSequence).to receive(:new).with([GrpcMock::Response::ExceptionValue, GrpcMock::Response::ExceptionValue]).once
+        expect(stub_grpc_action.to_raise(exception, exception)).to eq(stub_grpc_action)
+      end
+    end
+  end
+
+  describe '#match?' do
+    it { expect(stub_grpc_action.match?(path, double(:request))).to eq(true) }
+  end
+end

--- a/spec/grpc_mock_spec.rb
+++ b/spec/grpc_mock_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe GrpcMock do
         end
 
         context 'with not equal request' do
-          let(:request_params) { { msg: 'hello2!' } }
+          let(:request_params) { { msg: 'hello!' } }
 
           before do
             GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(**request_params).to_return(**response_params)
@@ -158,7 +158,7 @@ RSpec.describe GrpcMock do
         end
 
         context 'with not equal request' do
-          let(:request) { Hello::HelloRequest.new(msg: 'hello2!') }
+          let(:request) { Hello::HelloRequest.new(msg: 'hello!') }
 
           before do
             GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(request).to_return(response)

--- a/spec/grpc_mock_spec.rb
+++ b/spec/grpc_mock_spec.rb
@@ -46,23 +46,41 @@ RSpec.describe GrpcMock do
       double(input: Hello::HelloRequest, output: Hello::HelloResponse)
     end
 
-    context 'with to_return' do
-      let(:response) { { msg: 'test' } }
+    context 'with #to_return' do
+      shared_examples_for "returns response" do
+        it { expect(client.send_message('hello!')).to eq(response) }
 
-      before do
-        described_class.enable!
-        GrpcMock.stub_grpc_action('/hello.hello/Hello', action).to_return(response)
+        context 'when return_op is true' do
+          let(:client_call) { client.send_message('hello!', return_op: true) }
+
+          it 'returns an executable operation' do
+            expect(client_call).to be_a GrpcMock::OperationStub
+            expect(client_call.execute).to eq response
+          end
+        end
       end
 
-      it { expect(client.send_message('hello!')).to eq(Hello::HelloResponse.new(response)) }
+      context "when passed param is hash" do
+        let(:params) { { msg: 'test' } }
+        let(:response) { Hello::HelloResponse.new(params) }
 
-      context 'when return_op is true' do
-        let(:client_call) { client.send_message('hello!', return_op: true) }
-
-        it 'returns an executable operation' do
-          expect(client_call).to be_a GrpcMock::OperationStub
-          expect(client_call.execute).to eq Hello::HelloResponse.new(response)
+        before do
+          described_class.enable!
+          GrpcMock.stub_grpc_action('/hello.hello/Hello', action).to_return(**params)
         end
+
+        it_behaves_like "returns response"
+      end
+
+      context "when passed param is proto object" do
+        let(:response) { Hello::HelloResponse.new(msg: 'test') }
+
+        before do
+          described_class.enable!
+          GrpcMock.stub_grpc_action('/hello.hello/Hello', action).to_return(response)
+        end
+
+        it_behaves_like "returns response"
       end
     end
 
@@ -78,34 +96,76 @@ RSpec.describe GrpcMock do
     end
 
     describe '.with' do
-      let(:response) { { msg: 'test' } }
+      context "when passed param is hash" do
+        let(:request_params) { { msg: 'hello!' } }
+        let(:response_params) { { msg: 'test' } }
+        let(:response) { Hello::HelloResponse.new(response_params) }
 
-      context 'with equal request' do
-        before do
-          GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(msg: 'hello2!').to_return(response)
+        context 'with equal request' do
+          before do
+            GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(**request_params).to_return(**response_params)
+          end
+
+          it { expect(client.send_message('hello!')).to eq(response) }
+
+          context 'and they are two mocking request' do
+            let(:response_params2) { { msg: 'test2' } }
+            let(:response2) { Hello::HelloResponse.new(response_params2) }
+
+            before do
+              GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(**request_params).to_return(**response_params2)
+            end
+
+            it 'returns newest result' do
+              expect(client.send_message('hello!')).to eq(response2)
+            end
+          end
         end
 
-        it { expect(client.send_message('hello2!')).to eq(Hello::HelloResponse.new(response)) }
-
-        context 'and they are two mocking request' do
-          let(:response2) { { msg: 'test2' } }
+        context 'with not equal request' do
+          let(:request_params) { { msg: 'hello2!' } }
 
           before do
-            GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(msg: 'hello2!').to_return(response2)
+            GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(**request_params).to_return(**response_params)
           end
 
-          it 'returns newest result' do
-            expect(client.send_message('hello2!')).to eq(Hello::HelloResponse.new(response2))
-          end
+          it { expect { client.send_message('hello2!') }.to raise_error(GRPC::Unavailable) }
         end
       end
 
-      context 'with not equal request' do
-        before do
-          GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(msg: 'hello!').to_return(response)
+      context "when passed param is proto object" do
+        let(:request) { Hello::HelloRequest.new(msg: 'hello!') }
+        let(:response) { Hello::HelloResponse.new(msg: 'test') }
+
+        context 'with equal request' do
+          before do
+            GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(request).to_return(response)
+          end
+
+          it { expect(client.send_message('hello!')).to eq(response) }
+
+          context 'and they are two mocking request' do
+            let(:response2) { Hello::HelloResponse.new(msg: 'test2') }
+
+            before do
+              GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(request).to_return(response2)
+            end
+
+            it 'returns newest result' do
+              expect(client.send_message('hello!')).to eq(response2)
+            end
+          end
         end
 
-        it { expect { client.send_message('hello2!') }.to raise_error(GRPC::Unavailable) }
+        context 'with not equal request' do
+          let(:request) { Hello::HelloRequest.new(msg: 'hello2!') }
+
+          before do
+            GrpcMock.stub_grpc_action('/hello.hello/Hello', action).with(request).to_return(response)
+          end
+
+          it { expect { client.send_message('hello2!') }.to raise_error(GRPC::Unavailable) }
+        end
       end
     end
   end


### PR DESCRIPTION
Adding a feature to use hashes as a stubbing mechanism for GrpcMock.

Example of usage:
https://github.com/Freshly/labyrinth/pull/324
https://github.com/Freshly/freshly/pull/10144